### PR TITLE
A little fix in spanish translation

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,7 +11,7 @@
   <string name="number_saved">Número telefónico guardado</string>
   <string name="pref_gps_name">Solicitar GPS</string>
   <string name="gps_description">Texto para ordenar solicitud de GPS (y respuesta)</string>
-  <string name="pref_wifi_name">Solicitar WiFi/string></string>
+  <string name="pref_wifi_name">Solicitar WiFi</string>
   <string name="wifi_description">Texto para ordenar solicitud de GPS (y respuesta)</string>
   <string name="title_activity_maps">Mapa</string>
   <string name="api_error">Error API de Google Geolocation</string>


### PR DESCRIPTION
Hello and thanks for this pull request about Spanish translation. But, I find a string with "/string>" and I think that this is strange. So I fix it.